### PR TITLE
add possibility to omit config

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Greenkeeper badge](https://badges.greenkeeper.io/inthepocket/fastify-typeorm-plugin.svg)](https://greenkeeper.io/)
 [![Coverage Status](https://coveralls.io/repos/github/inthepocket/fastify-typeorm-plugin/badge.svg?branch=master)](https://coveralls.io/github/inthepocket/fastify-typeorm-plugin?branch=master)
 
-Fastify plugin for TypeORM for sharing the same TypeORM connection in every part of your server.  
+Fastify plugin for TypeORM for sharing the same TypeORM connection in every part of your server.
 Under the hood the official [TypeORM](https://www.npmjs.com/package/typeorm) module is used.
 
 ## Install
@@ -16,7 +16,7 @@ npm install fastify-typeorm-plugin
 
 ## Usage
 
-Add it to your project with `register` and you are done!  
+Add it to your project with `register` and you are done!
 The plugin accepts the [same connection options](https://typeorm.io/#/connection-options) as the TypeORM client.
 
 ```js
@@ -28,6 +28,29 @@ fastify.register(require('fastify-typeorm-plugin'), {
   type: 'sqlite',
   database: './mydb.sql',
 });
+
+fastify.get('/users', async function(req, reply) {
+  const users = await this.orm
+    .getRepository(User)
+    .createQueryBuilder('user')
+    .getMany();
+
+  return users;
+});
+
+fastify.listen(3000, err => {
+  if (err) throw err;
+});
+```
+
+If you won't pass config, it will use `typeorm` default [createConnection](https://typeorm.io/#/connection/creating-a-new-connection) mechanism:
+
+```js
+const fastify = require('fastify')();
+
+const user = require('./entity/user');
+
+fastify.register(require('fastify-typeorm-plugin'));
 
 fastify.get('/users', async function(req, reply) {
   const users = await this.orm

--- a/index.js
+++ b/index.js
@@ -7,7 +7,14 @@ async function typeormConnector (fastify, options) {
   const { namespace } = options
   delete options.namespace
 
-  const connection = options.connection || await createConnection(options)
+  let connection
+  if (options.connection) {
+    connection = options.connection
+  } else if (Object.keys(options).length) {
+    connection = await createConnection(options)
+  } else {
+    connection = await createConnection()
+  }
 
   if (namespace) {
     if (!fastify.orm) {

--- a/test.js
+++ b/test.js
@@ -21,6 +21,20 @@ test('Postgres available', async t => {
   await fastify.close()
 })
 
+test('Postgres available through env variables', async t => {
+  process.env.TYPEORM_CONNECTION = 'postgres'
+  process.env.TYPEORM_HOST = 'localhost'
+  process.env.TYPEORM_USERNAME = 'postgres'
+  process.env.TYPEORM_DATABASE = 'postgres'
+  process.env.TYPEORM_PORT = '5432'
+  const fastify = Fastify()
+  fastify.register(fastifyORM)
+
+  await fastify.ready()
+  t.strictEqual(fastify.orm.name, 'default')
+  await fastify.close()
+})
+
 test('with unreachable db', async t => {
   const fastify = Fastify()
   fastify.register(fastifyORM, { host: 'localhost', type: 'orm' })


### PR DESCRIPTION
Hey guys, thank you for the plugin!
I was struggling for 2 days trying to get it working with configuring typeorm through env variables, and discovered that `fastify` always passing `{}` to `async function typeormConnector (fastify, options) {` for `options`, which makes it call `createConnection` with that empty object even if user registered plugin without passing it. And `typeorm.createConnection({})` seems to trying to find config in object passed and stucks, so basically that plugin does not support env-like setup. I've added couple of guards to check if passed object is empty, treat it as `undefined` passed to `createConnection`, added tests for it, updated documentation, and tested locally with my `fastify` project as well.
Looking forward to merge it, since its blocking my app from using env variables for `typeorm` with this cool plugin. :) 